### PR TITLE
feat: add clippy CI contribution to agent-browser post

### DIFF
--- a/services/blog/data/blog/agent-browser.mdx
+++ b/services/blog/data/blog/agent-browser.mdx
@@ -376,3 +376,4 @@ agent-browser는 그 조각을 채워넣고 있다.
 | PR | 이슈 | 제목 | 상태 | 머지일 |
 |----|------|------|------|--------|
 | [#573](https://github.com/vercel-labs/agent-browser/pull/573) | [#500](https://github.com/vercel-labs/agent-browser/issues/500) | fix: resolve unnamed element refs matching multiple elements | MERGED | 2026-03-01 |
+| [#675](https://github.com/vercel-labs/agent-browser/pull/675) | [#672](https://github.com/vercel-labs/agent-browser/issues/672) | ci: add clippy check to Rust CI workflow | MERGED | 2026-03-07 |


### PR DESCRIPTION
Add PR #675 (issue #672) to contribution table - clippy check added to Rust CI workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds a single row to a blog post’s contribution table with no runtime or build impact.
> 
> **Overview**
> Updates the `services/blog/data/blog/agent-browser.mdx` post by adding PR `#675` (issue `#672`) to the **Contribution** table, documenting the merged change that adds a Rust `clippy` check to the upstream CI workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a6bd119bad69da3610be58dda321d4e96a18da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->